### PR TITLE
Fixes for Python3.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,9 @@
 from binaryninja import PluginCommand, log
-from utils import RunInBackground
-from rtti import scan_for_rtti, create_vtable
-from unwind import parse_unwind_info
-from fixes import fix_x86_conventions
-from tls import label_tls
+from .utils import RunInBackground
+from .rtti import scan_for_rtti, create_vtable
+from .unwind import parse_unwind_info
+from .fixes import fix_x86_conventions
+from .tls import label_tls
 
 
 def command_scan_for_rtti(view):

--- a/pefile/pefile.py
+++ b/pefile/pefile.py
@@ -35,7 +35,7 @@ import re
 import string
 import array
 import mmap
-import ordlookup
+from . import ordlookup
 
 from collections import Counter
 from hashlib import sha1

--- a/rtti.py
+++ b/rtti.py
@@ -1,6 +1,6 @@
 from binaryninja import Symbol, Type, log, demangle
 from binaryninja.enums import SymbolType
-from utils import BinjaStruct, read_cstring, check_address, update_percentage
+from .utils import BinjaStruct, read_cstring, check_address, update_percentage
 
 
 def check_rtti_signature(view, magic):

--- a/tls.py
+++ b/tls.py
@@ -1,7 +1,7 @@
 from binaryninja import Symbol, Type, log
 from binaryninja.enums import SymbolType
 
-from utils import BinjaStruct, read_pe_header, check_address
+from .utils import BinjaStruct, read_pe_header, check_address
 
 
 IMAGE_TLS_DIRECTORY32_t = BinjaStruct('<IIIIII', names = ('StartAddressOfRawData', 'EndAddressOfRawData', 'AddressOfIndex', 'AddressOfCallBacks', 'SizeOfZeroFill', 'Characteristics'))

--- a/unwind.py
+++ b/unwind.py
@@ -1,5 +1,5 @@
 from binaryninja import log
-from utils import BinjaStruct, read_pe_header, split_bits, update_percentage
+from .utils import BinjaStruct, read_pe_header, split_bits, update_percentage
 
 # https://msdn.microsoft.com/en-us/library/ft9x1kdx.aspx
 


### PR DESCRIPTION
To get the plugins working with Python3(.5) I needed to explicitly state that the modules should be loaded from the plugin directory.

Maybe there is a more elegant way to do this?